### PR TITLE
Add a simple webpack based build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+dist
 .DS_Store
 node_modules
 npm-debug.log
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vue-info-box",
   "version": "0.9.5",
   "description": "A simple component for vuejs 2.0 to display different types of info boxes",
-  "main": "main.js",
+  "main": "./dist/vue-info-box.js",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ainzz/vue-info-box.git"
@@ -23,5 +23,23 @@
   "peerDependencies": {
     "vue": "2.x.x",
     "font-awesome": "4.x.x"
+  },
+  "scripts": {
+    "dev": "cross-env NODE_ENV=development webpack --progress --watch",
+    "build": "cross-env NODE_ENV=production webpack --progress --hide-modules",
+    "prepare": "npm run build"
+  },
+  "files": [
+    "dist/vue-info-box.js"
+  ],
+  "devDependencies": {
+    "babel-core": "^6.26.0",
+    "babel-loader": "^7.1.2",
+    "babel-preset-env": "^1.6.1",
+    "cross-env": "^5.1.0",
+    "css-loader": "^0.28.7",
+    "vue-loader": "^13.3.0",
+    "vue-template-compiler": "^2.5.2",
+    "webpack": "^3.8.1"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,46 @@
+const webpack = require('webpack');
+const path = require('path');
+const PROD = process.env.NODE_ENV === 'production';
+
+module.exports = {
+    entry: path.resolve(__dirname + '/main.js'),
+
+    output: {
+        path: path.resolve(__dirname + '/dist/'),
+        filename: 'vue-info-box.js',
+
+        libraryTarget: 'umd',
+        library: 'vue-info-box',
+        umdNamedDefine: true,
+    },
+
+    module: {
+        loaders: [
+            {
+                test: /\.vue$/,
+                loader: 'vue-loader',
+                options: {
+                    loaders: {
+                        js: {
+                            loader: 'babel-loader',
+                            options: {
+                                presets: ['env'],
+                            },
+                        },
+                    },
+                },
+            },
+        ],
+    },
+
+    plugins: [
+        new webpack.optimize.UglifyJsPlugin({
+            minimize: PROD ? true : false,
+            sourceMap: PROD ? false : true,
+            mangle: PROD ? true: false,
+            compress: {
+                warnings: PROD ? false: true
+            },
+        }),
+    ],
+};


### PR DESCRIPTION
This adds a simple, webpack-based build for your vue component that'll produce a file that doesn't necessarily force the parent project to use vue-loader, ES6, etc. It also helps with compatibility with uglify.